### PR TITLE
Minor changes to progress bar prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/qutip/QuantumToolbox.jl/tree/main)
 
 - Introduce new methods of `sesolve_map` and `mesolve_map` for advanced usage. Users can now customize their own `iter`ator structure, `prob_func` and `output_func`. ([#565])
-- Use `ProgressMeter.jl` for progress bar rather than our in-house implementation. ([#569])
+- Use `ProgressMeter.jl` for progress bar rather than our in-house implementation. ([#569], [#575])
 
 ## [v0.37.0]
 Release date: 2025-10-12
@@ -341,3 +341,4 @@ Release date: 2024-11-13
 [#557]: https://github.com/qutip/QuantumToolbox.jl/issues/557
 [#565]: https://github.com/qutip/QuantumToolbox.jl/issues/565
 [#569]: https://github.com/qutip/QuantumToolbox.jl/issues/569
+[#575]: https://github.com/qutip/QuantumToolbox.jl/issues/575

--- a/src/time_evolution/callback_helpers/callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/callback_helpers.jl
@@ -57,10 +57,10 @@ end
 function _generate_save_callback(e_ops, tlist, progress_bar, method)
     e_ops_data = e_ops isa Nothing ? nothing : _get_e_ops_data(e_ops, method)
 
-    progr_desc = _get_progress_desc(method)
     progr =
         getVal(progress_bar) ?
-        Progress(length(tlist), showspeed = true, enabled = getVal(progress_bar), desc = progr_desc) : nothing
+        Progress(length(tlist), showspeed = true, enabled = getVal(progress_bar), desc = _get_progress_desc(method)) :
+        nothing
 
     expvals = e_ops isa Nothing ? nothing : Array{ComplexF64}(undef, length(e_ops), length(tlist))
 

--- a/src/time_evolution/callback_helpers/mesolve_callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/mesolve_callback_helpers.jl
@@ -14,7 +14,7 @@ end
 
 _get_e_ops_data(e_ops, ::Type{SaveFuncMESolve}) = [_generate_mesolve_e_op(op) for op in e_ops] # Broadcasting generates type instabilities on Julia v1.10
 
-_get_progress_desc(::Type{SaveFuncMESolve}) = "(mesolve) "
+_get_progress_desc(::Type{SaveFuncMESolve}) = "[mesolve] "
 
 ##
 

--- a/src/time_evolution/callback_helpers/sesolve_callback_helpers.jl
+++ b/src/time_evolution/callback_helpers/sesolve_callback_helpers.jl
@@ -14,7 +14,7 @@ end
 
 _get_e_ops_data(e_ops, ::Type{SaveFuncSESolve}) = get_data.(e_ops)
 
-_get_progress_desc(::Type{SaveFuncSESolve}) = "(sesolve) "
+_get_progress_desc(::Type{SaveFuncSESolve}) = "[sesolve] "
 
 ##
 

--- a/src/time_evolution/mcsolve.jl
+++ b/src/time_evolution/mcsolve.jl
@@ -243,7 +243,7 @@ function mcsolveEnsembleProblem(
             progress_bar,
             ntraj,
             _mcsolve_output_func;
-            progr_desc = "(mcsolve) ",
+            progr_desc = "[mcsolve] ",
         ) : output_func
 
     prob_mc = mcsolveProblem(

--- a/src/time_evolution/mesolve.jl
+++ b/src/time_evolution/mesolve.jl
@@ -373,7 +373,7 @@ function mesolve_map(
             progress_bar,
             ntraj,
             _standard_output_func;
-            progr_desc = "(mesolve_map) ",
+            progr_desc = "[mesolve_map] ",
         ) : output_func
     ens_prob = TimeEvolutionProblem(
         EnsembleProblem(prob.prob, prob_func = _prob_func, output_func = _output_func[1], safetycopy = false),

--- a/src/time_evolution/sesolve.jl
+++ b/src/time_evolution/sesolve.jl
@@ -282,7 +282,7 @@ function sesolve_map(
             progress_bar,
             ntraj,
             _standard_output_func;
-            progr_desc = "(sesolve_map) ",
+            progr_desc = "[sesolve_map] ",
         ) : output_func
     ens_prob = TimeEvolutionProblem(
         EnsembleProblem(prob.prob, prob_func = _prob_func, output_func = _output_func[1], safetycopy = false),

--- a/src/time_evolution/smesolve.jl
+++ b/src/time_evolution/smesolve.jl
@@ -254,7 +254,7 @@ function smesolveEnsembleProblem(
             progress_bar,
             ntraj,
             _standard_output_func;
-            progr_desc = "(smesolve) ",
+            progr_desc = "[smesolve] ",
         ) : output_func
 
     prob_sme = smesolveProblem(

--- a/src/time_evolution/ssesolve.jl
+++ b/src/time_evolution/ssesolve.jl
@@ -248,7 +248,7 @@ function ssesolveEnsembleProblem(
             progress_bar,
             ntraj,
             _standard_output_func;
-            progr_desc = "(ssesolve) ",
+            progr_desc = "[ssesolve] ",
         ) : output_func
 
     prob_sme = ssesolveProblem(


### PR DESCRIPTION
## Checklist
Thank you for contributing to `QuantumToolbox.jl`! Please make sure you have finished the following tasks before opening the PR.

- [ ] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [ ] Any code changes were done in a way that does not break public API.
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
- [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR change the prefix from, for example, `(sesolve) ` to `[sesolve] `